### PR TITLE
Refactor BaseStrategi into BaseApi

### DIFF
--- a/tests/test_base_strategy/strategy.py
+++ b/tests/test_base_strategy/strategy.py
@@ -24,7 +24,7 @@ class DeribitTestStrategy(StrategyBase):
             config: dict,
             logger: Logger = None,
     ):
-        trading_symbols = [("deribit", "BTC-PERPETUAL")]
+        trading_symbols = [("deribit", "BTC-PERPETUAL"), ("deribit", "ETH-PERPETUAL")]
 
         super().__init__(
             app_runner,


### PR DESCRIPTION
1. Move barries keys into DependencyActions
2. Rename BaseStrategy into PhxApi
3. Change PhxApi code to be implement all abstract methods and contain all account and market data.
4. Implement methods for accessing all account and market data