### PR TITLE
Add start and end times to FIX configs

### DIFF
--- a/src/phx/api/interface.py
+++ b/src/phx/api/interface.py
@@ -28,7 +28,7 @@ class ApiInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def stop_api(self):
+    def teardown_open_orders(self):
         pass
 
     @abc.abstractmethod
@@ -64,7 +64,7 @@ class ApiInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def stop_threads(self):
+    def stop_timer_thread(self):
         pass
 
     @abc.abstractmethod

--- a/src/phx/fix/app/config.py
+++ b/src/phx/fix/app/config.py
@@ -111,6 +111,8 @@ class FixSessionConfig(object):
             socket_connect_host="127.0.0.1",
             data_dir=None,
             fix_schema_dict: str = None,
+            start_time="00:00:00",
+            end_time="00:00:00",
             root=None
     ):
         self.sender_comp_id = sender_comp_id
@@ -131,7 +133,7 @@ class FixSessionConfig(object):
         self.settings = fix.SessionSettings()
         self.settings.set(
             dict_to_fix_dict(
-                fix_session_default_config(self.log_dir)
+                fix_session_default_config(self.log_dir, start_time, end_time)
             )
         )
 

--- a/src/phx/fix/utils/fix.py
+++ b/src/phx/fix/utils/fix.py
@@ -482,7 +482,8 @@ def dict_to_fix_dict(d: dict) -> fix.Dictionary:
     return fd
 
 
-def fix_session_default_config(file_log_path="./logs/") -> dict:
+def fix_session_default_config(file_log_path="./logs/", start_time="00:00:00", end_time="00:00:00") -> dict:
+
     """
     Settings that apply to all the sessions
     """
@@ -490,8 +491,8 @@ def fix_session_default_config(file_log_path="./logs/") -> dict:
         "DefaultApplVerID": "FIX.4.4",
         "ConnectionType": "initiator",
         "FileLogPath": file_log_path,
-        "StartTime": "00:00:00",
-        "EndTime": "00:00:00",
+        "StartTime": start_time,
+        "EndTime": end_time,
         "NonStopSession": "N",
         "UseDataDictionary": "Y",
         "ReconnectInterval": 60,


### PR DESCRIPTION
FIX configs:
In the files src/phx/fix/app/config.py and src/phx/fix/utils/fix.py: FixSessionConfig can now be constructed via the arguments of start_time and end_time. This setup would be very useful in testing FIX connectivity later on. 

Minor name changes (as in the previous PR):
In the files src/phx/api/interface.py and src/phx/api/phx_api.py.
1. For self.position_report_counter, self.order_books and self.security_list. In the typing annotations, Tuple[str, str] is changed to Ticker.
2. self.stop_api is renamed to self.teardown_open_orders.
3. self.stop_threads is renamed to self.stop_timer_thread (as ONLY the timer thread is stopped in this function).