### PR TITLE
Minor refactoring on order status tracking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ netifaces-plus
 pytest
 deepdiff
 prometheus_client
+eventkit
 
 # arch other than arm64 and Windows should be able to install quickfix without a patch
 quickfix; platform_machine != 'arm64' and sys_platform != 'win32'

--- a/src/phx/fix/tracker/order_tracker.py
+++ b/src/phx/fix/tracker/order_tracker.py
@@ -36,9 +36,7 @@ class OrderTrackerBase(object):
         self.snapshots_obtained = False
 
     @abc.abstractmethod
-    def process(self, report: ExecReport, sending_time) -> Union[
-        Tuple[Optional[Order], int, ExecReport, Optional[str]], Union[ExecReport, List[ExecReport]]
-    ]:
+    def process(self, report: ExecReport, sending_time) -> Tuple[Optional[Order], Optional[str]]:
         pass
 
     def purge_history(self):
@@ -216,6 +214,7 @@ class OrderTracker(OrderTrackerBase):
 
                 # store it but do not remove it as it is still active but failed to be updated
                 self.rejected_open_orders[report.ord_id] = order
+                del self.open_orders[report.cl_ord_id]
 
             if order is None:
                 error = (

--- a/src/phx/fix/tracker/order_tracker.py
+++ b/src/phx/fix/tracker/order_tracker.py
@@ -214,7 +214,8 @@ class OrderTracker(OrderTrackerBase):
 
                 # store it but do not remove it as it is still active but failed to be updated
                 self.rejected_open_orders[report.ord_id] = order
-                del self.open_orders[report.cl_ord_id]
+                if order.ord_status == fix.OrdStatus_PENDING_NEW:
+                    del self.open_orders[report.cl_ord_id]
 
             if order is None:
                 error = (


### PR DESCRIPTION
1.  src/phx/api/phx_api.py: For the case of fix.OrdStatus_REJECTED, we should run self.order_tracker.process instead of self.on_reject_exec_report(msg), which merely prints out the rejection message. 
2. src/phx/api/phx_api.py: There is now an event "on_order_update_event" that takes in order updates, which can be subscribed in actual strategy classes. 
3. src/phx/fix/tracker/order_tracker.py: report.cl_ord_id is removed from self.open_orders in the event of order rejection. 